### PR TITLE
do not print an extra newline

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,7 @@ module.exports = function(stream) {
 	var str;
 
 	stream.write = function(data) {
-		if (str && data !== str) {
-			str = null;
-			write.call(this, '\n');
-		}
+		if (str && data !== str) str = null;
 		write.apply(this, arguments);
 	};
 


### PR DESCRIPTION
no need to print an extra newline since single-line-log supports newlines in the input now yay.
