### PR TITLE
Fix previousLineCount calculation

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,9 +34,9 @@ module.exports = function(stream) {
 
 		// How many lines to remove on next clear screen
 		var prevLines = nextStr.split('\n');
-		prevLineCount = prevLines.length;
+		prevLineCount = 0;
 		for (var i=0; i < prevLines.length; i++) {
-			if (stream.columns < stringWidth(prevLines[i])) prevLineCount += 1;
+			prevLineCount += Math.ceil(stringWidth(prevLines[i]) / stream.columns) || 1;
 		}
 	};
 


### PR DESCRIPTION
Previously the previousLineCount only added one extra line if the input wrapped, which would fail if the line was more than twice the width of the terminal.
