### PR TITLE
Keep the current output

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,23 @@ Clears the log (i.e., writes a newline).
 ``` js
 var log = require('single-line-log').stdout;
 
-log('Line 1');
-log.clear();
-log('Line 2');
+log('Line 1'); // Output is `Line 1`
+log.clear(); // Output is ``
+log('Line 2'); // Output is `Line 2`
 ```
 
+## .keepOutput()
+
+Keeps the current output, and begins a new buffer.
+
+``` js
+var log = require('single-line-log').stdout;
+
+log('Line 1\n'); // Output is `Line 1\n`
+log.keepOutput(); // Output is `Line 1\n`
+log('Line 2\n'); // Output is `Line 1\nLine 2\n`
+log('Line 3\n'); // Output is `Line 1\nLine 3\n`
+```
 
 ## .stdout
 

--- a/index.js
+++ b/index.js
@@ -44,6 +44,10 @@ module.exports = function(stream) {
 		stream.write('');
 	};
 
+	log.keepContent = function() {
+		prevLineCount = 0;
+	};
+
 	return log;
 };
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function(stream) {
 		stream.write('');
 	};
 
-	log.keepContent = function() {
+	log.keepOutput = function() {
 		prevLineCount = 0;
 	};
 


### PR DESCRIPTION
There is plenty of use-cases for keeping the current output, such as showing progress while a task is running and then keeping the result when starting the next task.

Unfortunately, in the current version of tool, it is not easy. This change makes it very easy.
